### PR TITLE
Fix 'openssl_fips' is not defined on some systems

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+    "variables": {
+        "openssl_fips" : "0" 
+    },
     "targets": [
         {
             "target_name": "system-fonts",

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,7 @@
 {
+    'xcode_settings': {
+        'CLANG_CXX_LANGUAGE_STANDARD': 'c++17'
+    },
     "variables": {
         "openssl_fips" : "0" 
     },

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   "bugs": {
     "url": "https://github.com/jgilsaa/node-system-fonts.git/issues"
   },
-  "homepage": "https://github.com/jgilsaa/node-system-fonts.git"
+  "homepage": "https://github.com/jgilsaa/node-system-fonts.git",
+  "resolutions": {
+    "nan": "github:jkleinsc/nan#remove_accessor_signature"
+  }
 }


### PR DESCRIPTION
I was getting the error **'openssl_fips' is not defined** on some systems when npm installing the module. This seems to fix it