### PR TITLE
Fix win crash on inconsistent font status

### DIFF
--- a/src/lib/FontManagerWindows.cc
+++ b/src/lib/FontManagerWindows.cc
@@ -190,12 +190,13 @@ ResultSet *getAvailableFonts() {
 
     for (int j = 0; j < fontCount; j++) {
       IDWriteFont *font = NULL;
-      HR(family->GetFont(j, &font));
+      if (family->GetFont(j, &font) >= 0) {
 
-      FontDescriptor *result = resultFromFont(font);
-      if (psNames.count(result->postscriptName) == 0) {
-        res->push_back(resultFromFont(font));
-        psNames.insert(result->postscriptName);
+        FontDescriptor *result = resultFromFont(font);
+        if (psNames.count(result->postscriptName) == 0) {
+          res->push_back(resultFromFont(font));
+          psNames.insert(result->postscriptName);
+        }
       }
     }
 


### PR DESCRIPTION
See https://github.com/rstudio/rstudio/issues/13007

This is a problem on a single particular machine we have, which seems to have some inconsistency in its fonts. For reasons we don't know. The Windows DirectWrite API calls provide a font family, and report a number of fonts in that family, but when you try to load them with `GetFont`, it fails, and then the `HR` macro throws an exception.

This PR ignores GetFont failures rather than throwing an exception, so will tolerate that inconsistency without crashing. 